### PR TITLE
PROJ-11_Button fix: reset properties before using mixin

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -1,9 +1,10 @@
 @import '@styles/typography';
 
 .button {
-  @include H3;
-
   all: unset;
+
+  /* stylelint-disable-next-line order/order */
+  @include H3;
 
   cursor: pointer;
 


### PR DESCRIPTION
- что бы по дэфолту стили текста внутри кнопки были согласно дизайну
- all: unset перекрывало миксин. из-за правил линтера, он сам ставил его выше чем сброс.